### PR TITLE
readFile Encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Implements the concept of a filehandle that can be used to access local files, r
 
     // operate on a remote file path
     const remote = new RemoteFile('http://somesite.com/file.txt')
-    
+
     // operate on blob objects
     const blobfile = new BlobFile(new Blob([some_existing_buffer], { type: "text/plain" }))
 
@@ -40,9 +40,9 @@ Implements the concept of a filehandle that can be used to access local files, r
 
 Returns a promise containing bytesRead, and the results in the argument `buf`
 
-### async readFile(opts?: Options): Promise<Buffer>
+### async readFile(opts?: Options): Promise<Buffer | string>
 
-Returns a promise to a buffer for the whole file
+Returns a promise to a buffer or string for the whole file
 
 ### async stat() : Promise<{size: number}>
 
@@ -50,12 +50,18 @@ Returns a promise to a object containing at a minimum the size of the file
 
 ### Options
 
-The Options object for read and readFile can contain abort signal or other customizations. By default these are used
+The Options object for `read` and `readFile` can contain abort signal or other customizations. By default these are used
 
 * signal - an AbortSignal that is passed to remote file fetch() API or other file readers
 * headers - extra HTTP headers to pass to remote file fetch() API
 * overrides - extra parameters to pass to the remote file fetch() API
 
+The Options object for `readFile` can also contain an entry `encoding`. The
+default is no encoding, in which case the file contents are returned as a
+buffer. Currently, the only encoding that is consistent is "utf8", and
+specifying that will cause the file contents to be returned as a string. Also,
+passing the string "utf8" instead of an Options object is valid for `readFile`
+as well.
 
 ## References
 

--- a/src/blobFile.ts
+++ b/src/blobFile.ts
@@ -2,6 +2,56 @@ interface Stats {
   size: number;
 }
 
+// Using this you can "await" the file like a normal promise
+// https://blog.shovonhasan.com/using-promises-with-filereader/
+function readBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  const fileReader = new FileReader();
+
+  return new Promise(
+    (resolve, reject): void => {
+      fileReader.onerror = (): void => {
+        fileReader.abort();
+        reject(new Error("problem reading blob"));
+      };
+
+      fileReader.onabort = (): void => {
+        reject(new Error("blob reading was aborted"));
+      };
+
+      fileReader.onload = (): void => {
+        if (fileReader.result && typeof fileReader.result !== "string")
+          resolve(fileReader.result);
+        else reject(new Error("unknown error reading blob"));
+      };
+      fileReader.readAsArrayBuffer(blob);
+    }
+  );
+}
+
+function readBlobAsText(blob: Blob): Promise<string> {
+  const fileReader = new FileReader();
+
+  return new Promise(
+    (resolve, reject): void => {
+      fileReader.onerror = (): void => {
+        fileReader.abort();
+        reject(new Error("problem reading blob"));
+      };
+
+      fileReader.onabort = (): void => {
+        reject(new Error("blob reading was aborted"));
+      };
+
+      fileReader.onload = (): void => {
+        if (fileReader.result && typeof fileReader.result === "string")
+          resolve(fileReader.result);
+        else reject(new Error("unknown error reading blob"));
+      };
+      fileReader.readAsText(blob);
+    }
+  );
+}
+
 /**
  * Blob of binary data fetched from a local file (with FileReader).
  *
@@ -14,34 +64,6 @@ export default class BlobFile implements Filehandle {
   public constructor(blob: Blob) {
     this.blob = blob;
     this.size = blob.size;
-  }
-
-  // Using this you can "await" the file like a normal promise
-  // https://blog.shovonhasan.com/using-promises-with-filereader/
-  private readBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
-    const temporaryFileReader = new FileReader();
-
-    return new Promise(
-      (resolve, reject): void => {
-        temporaryFileReader.onerror = (): void => {
-          temporaryFileReader.abort();
-          reject(new Error(`problem reading blob`));
-        };
-
-        temporaryFileReader.onabort = (): void => {
-          reject(new Error(`blob reading was aborted`));
-        };
-
-        temporaryFileReader.onload = (): void => {
-          if (
-            temporaryFileReader.result &&
-            typeof temporaryFileReader.result !== "string"
-          )
-            resolve(temporaryFileReader.result);
-        };
-        temporaryFileReader.readAsArrayBuffer(blob);
-      }
-    );
   }
 
   public async read(
@@ -59,9 +81,7 @@ export default class BlobFile implements Filehandle {
     const start = position;
     const end = start + length;
 
-    const result = await this.readBlobAsArrayBuffer(
-      this.blob.slice(start, end)
-    );
+    const result = await readBlobAsArrayBuffer(this.blob.slice(start, end));
     const resultBuffer = Buffer.from(result);
 
     resultBuffer.copy(buffer, offset);
@@ -69,8 +89,13 @@ export default class BlobFile implements Filehandle {
     return result.byteLength;
   }
 
-  public async readFile(): Promise<Buffer> {
-    const result = await this.readBlobAsArrayBuffer(this.blob);
+  public async readFile(options?: Options | string): Promise<Buffer | string> {
+    let encoding;
+    if (typeof options === "string") encoding = options;
+    else encoding = options && options.encoding;
+    if (encoding === "utf8") return readBlobAsText(this.blob);
+    if (encoding) throw new Error(`unsupported encoding: ${encoding}`);
+    const result = await readBlobAsArrayBuffer(this.blob);
     return Buffer.from(result);
   }
 

--- a/src/filehandle.ts
+++ b/src/filehandle.ts
@@ -2,6 +2,7 @@ declare interface Options {
   signal?: AbortSignal;
   headers?: any;
   overrides?: any;
+  encoding?: string | null;
 }
 
 declare interface Filehandle {
@@ -12,5 +13,5 @@ declare interface Filehandle {
     position: number,
     opts?: Options
   ): Promise<number>;
-  readFile(): Promise<Buffer>;
+  readFile(options?: Options): Promise<Buffer | string>;
 }

--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -27,8 +27,8 @@ export default class LocalFile implements Filehandle {
     return ret;
   }
 
-  public async readFile(): Promise<Buffer> {
-    return fsReadFile(this.filename);
+  public async readFile(options?: Options | string): Promise<Buffer | string> {
+    return fsReadFile(this.filename, options);
   }
   // todo memoize
   public async stat(): Promise<any> {

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -55,7 +55,19 @@ export default class RemoteFile implements Filehandle {
     throw new Error(`HTTP ${response.status} fetching ${this.url}`);
   }
 
-  public async readFile(opts: Options = {}): Promise<Buffer> {
+  public async readFile(
+    options: Options | string = {}
+  ): Promise<Buffer | string> {
+    let encoding;
+    let opts;
+    if (typeof options === "string") {
+      encoding = options;
+      opts = {};
+    } else {
+      encoding = options.encoding;
+      opts = options;
+      delete opts.encoding;
+    }
     const { headers = {}, signal, overrides = {} } = opts;
     const response = await fetch(this.url, {
       headers,
@@ -65,6 +77,8 @@ export default class RemoteFile implements Filehandle {
       signal,
       ...overrides
     });
+    if (encoding === "utf8") return response.text();
+    if (encoding) throw new Error(`unsupported encoding: ${encoding}`);
     return Buffer.from(await response.arrayBuffer());
   }
 

--- a/test/blobFile.test.ts
+++ b/test/blobFile.test.ts
@@ -10,6 +10,18 @@ describe("blob filehandle", () => {
     const fileContents = await blobFile.readFile();
     expect(fileContents.toString()).toEqual("testing\n");
   });
+  it("reads whole file with encoding", async () => {
+    const fileBuf = fs.readFileSync(require.resolve("./data/test.txt"));
+    const blob = new Blob([fileBuf], { type: "text/plain" });
+    const blobFile = new BlobFile(blob);
+    const fileContents = await blobFile.readFile("utf8");
+    expect(fileContents).toEqual("testing\n");
+    const fileContents2 = await blobFile.readFile({ encoding: "utf8" });
+    expect(fileContents2).toEqual("testing\n");
+    await expect(blobFile.readFile("fakeEncoding")).rejects.toThrow(
+      /unsupported encoding/
+    );
+  });
   it("reads file part", async () => {
     const fileBuf = fs.readFileSync(require.resolve("./data/test.txt"));
     const blob = new Blob([fileBuf], { type: "text/plain" });
@@ -18,6 +30,15 @@ describe("blob filehandle", () => {
     const bytesRead = await blobFile.read(buf, 0, 3, 0);
     expect(buf.toString()).toEqual("tes");
     expect(bytesRead).toEqual(3);
+  });
+  it("reads zero length file part", async () => {
+    const fileBuf = fs.readFileSync(require.resolve("./data/test.txt"));
+    const blob = new Blob([fileBuf], { type: "text/plain" });
+    const blobFile = new BlobFile(blob);
+    const buf = Buffer.allocUnsafe(3);
+    const bytesRead = await blobFile.read(buf, 0, 0, 0);
+    expect(buf.slice(0, bytesRead).toString()).toEqual("");
+    expect(bytesRead).toEqual(0);
   });
   it("reads file part clipped at end", async () => {
     const fileBuf = fs.readFileSync(require.resolve("./data/test.txt"));

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { LocalFile, open, fromUrl } from "../src/";
 
 describe("test util functions", () => {

--- a/test/localFile.test.ts
+++ b/test/localFile.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { LocalFile } from "../src/";
 
 describe("local file tests", () => {
@@ -5,6 +6,13 @@ describe("local file tests", () => {
     const f = new LocalFile(require.resolve("./data/test.txt"));
     const b = await f.readFile();
     expect(b.toString()).toEqual("testing\n");
+  });
+  it("reads file with encoding", async () => {
+    const f = new LocalFile(require.resolve("./data/test.txt"));
+    const fileText = await f.readFile("utf8");
+    expect(fileText).toEqual("testing\n");
+    const fileText2 = await f.readFile({ encoding: "utf8" });
+    expect(fileText2).toEqual("testing\n");
   });
   it("reads local file", async () => {
     const f = new LocalFile(require.resolve("./data/test.txt"));

--- a/test/remoteFile.test.ts
+++ b/test/remoteFile.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 import fetchMock from "fetch-mock";
 import { LocalFile, RemoteFile } from "../src/";
 import rangeParser from "range-parser";
@@ -40,6 +41,17 @@ describe("remote file tests", () => {
     const f = new RemoteFile("http://fakehost/test.txt");
     const b = await f.readFile();
     expect(b.toString()).toEqual("testing\n");
+  });
+  it("reads file with encoding", async () => {
+    fetchMock.mock("http://fakehost/test.txt", readFile);
+    const f = new RemoteFile("http://fakehost/test.txt");
+    const fileText = await f.readFile("utf8");
+    expect(fileText).toEqual("testing\n");
+    const fileText2 = await f.readFile({ encoding: "utf8" });
+    expect(fileText2).toEqual("testing\n");
+    await expect(f.readFile("fakeEncoding")).rejects.toThrow(
+      /unsupported encoding/
+    );
   });
   it("reads remote partially", async () => {
     fetchMock.mock("http://fakehost/test.txt", readBuffer);


### PR DESCRIPTION
Trying to stay consistent with node's [fs.readFile](https://nodejs.org/api/fs.html#fs_fs_readfile_path_options_callback), encoding can be specified in the Options object or as just a string.
```js
fileHandle.readFile("utf8")
// or
fileHandle.readFile({ encoding: "utf8" })
```

Also, only "utf8" works for now, since Blobs and Response Bodies don't actually support different encodings.