### PR TITLE
Add test for passing authorization token through remoteFile

### DIFF
--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -65,13 +65,13 @@ export default class RemoteFile implements GenericFilehandle {
     }
 
     const response = await this.fetch(this.url, {
-      headers,
+      ...this.baseOverrides,
+      ...overrides,
+      headers: { ...headers, ...overrides.headers, ...this.baseOverrides.headers },
       method: 'GET',
       redirect: 'follow',
       mode: 'cors',
       signal,
-      ...this.baseOverrides,
-      ...overrides,
     })
 
     if ((response.status === 200 && position === 0) || response.status === 206) {

--- a/test/remoteFile.test.ts
+++ b/test/remoteFile.test.ts
@@ -175,4 +175,42 @@ describe('remote file tests', () => {
     const stat = await f.stat()
     expect(stat.size).toEqual(8)
   })
+  it('auth token', async () => {
+    fetchMock.mock('http://fakehost/test.txt', (url: string, args: any) => {
+      if (args.headers.Authorization) {
+        return {
+          status: 200,
+          body: 'hello world',
+        }
+      } else {
+        return { status: 403 }
+      }
+    })
+    const f = new RemoteFile('http://fakehost/test.txt', {
+      overrides: { headers: { Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' } },
+    })
+    const stat = await f.readFile('utf8')
+    expect(stat).toBe('hello world')
+  })
+  it('auth token with range request', async () => {
+    fetchMock.mock('http://fakehost/test.txt', (url: string, args: any) => {
+      console.log(args.headers)
+      if (args.headers.Authorization && args.headers.range) {
+        return {
+          status: 206,
+          body: 'hello world',
+        }
+      } else if (!args.headers.Authorization) {
+        return { status: 403 }
+      } else if (!args.headers.Range) {
+        return { status: 400 }
+      }
+    })
+    const f = new RemoteFile('http://fakehost/test.txt', {
+      overrides: { headers: { Authorization: 'Basic YWxhZGRpbjpvcGVuc2VzYW1l' } },
+    })
+    const { buffer } = await f.read(Buffer.alloc(5), 0, 5, 0)
+    const str = buffer.toString()
+    expect(str).toBe('hello')
+  })
 })

--- a/test/remoteFile.test.ts
+++ b/test/remoteFile.test.ts
@@ -194,7 +194,6 @@ describe('remote file tests', () => {
   })
   it('auth token with range request', async () => {
     fetchMock.mock('http://fakehost/test.txt', (url: string, args: any) => {
-      console.log(args.headers)
       if (args.headers.Authorization && args.headers.range) {
         return {
           status: 206,


### PR DESCRIPTION
This attempts to allow people to override headers

The way that the code existed was that the headers would be "clobbered" by the spread. This makes it so that the override headers are merged more properly