### PR TITLE
Use cors-anywhere proxy as a fallback for some CORS errors

### DIFF
--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -102,6 +102,10 @@ export default class RemoteFile implements GenericFilehandle {
       }
     }
 
+    if (!response) {
+      throw new Error('generic-filehandle failed to fetch')
+    }
+
     if ((response.status === 200 && position === 0) || response.status === 206) {
       const responseData = await this.getBufferFromResponse(response)
       const bytesCopied = responseData.copy(
@@ -158,6 +162,10 @@ export default class RemoteFile implements GenericFilehandle {
     } catch (e) {
       this.prefix = this.corsProxy
       response = await this.fetch(this.prefix + this.url)
+    }
+
+    if (!response) {
+      throw new Error('generic-filehandle failed to fetch')
     }
 
     if (response.status !== 200) {

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -95,15 +95,16 @@ export default class RemoteFile implements GenericFilehandle {
     try {
       response = await this.fetch(this.prefix + this.url, args)
     } catch (e) {
-      console.log(e.message)
       if (e.message === 'Failed to fetch') {
         this.prefix = this.corsProxy
         response = await this.fetch(this.prefix + this.url, args)
+      } else {
+        throw e
       }
     }
 
-    if (!response) {
-      throw new Error('generic-filehandle failed to fetch')
+    if (!response.ok) {
+      throw new Error(`${response.statusText}`)
     }
 
     if ((response.status === 200 && position === 0) || response.status === 206) {

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -104,7 +104,7 @@ export default class RemoteFile implements GenericFilehandle {
     }
 
     if (!response.ok) {
-      throw new Error(`${response.statusText}`)
+      throw new Error(`HTTP ${response.status} ${response.statusText}`)
     }
 
     if ((response.status === 200 && position === 0) || response.status === 206) {

--- a/test/remoteFile.test.ts
+++ b/test/remoteFile.test.ts
@@ -136,7 +136,7 @@ describe('remote file tests', () => {
     const f = new RemoteFile('http://fakehost/test.txt')
     const buf = Buffer.alloc(10)
     const res = f.read(buf, 0, 0, 0)
-    await expect(res).rejects.toThrow(/fetching/)
+    await expect(res).rejects.toThrow(/Internal Server Error/)
   })
   it('throws error if file missing', async () => {
     fetchMock.mock('http://fakehost/test.txt', 404)


### PR DESCRIPTION
This is an attempt to automatically use a CORS proxy, to help access things like trackhubs

It might be that we could run our own cors-proxy also, using https://github.com/Rob--W/cors-anywhere

Xref
https://github.com/GMOD/jbrowse-components/issues/288

Note that CORS proxy is attempted when we get a "Failed to fetch" exception which is very nondescript but generally is what we get from a CORS error
