### PR TITLE
Refetch on CORS error with cache:'reload'

### DIFF
--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -164,6 +164,7 @@ export default class RemoteFile implements GenericFilehandle {
       method: 'GET',
       redirect: 'follow',
       mode: 'cors',
+      credentials: 'include',
       signal,
       ...this.baseOverrides,
       ...overrides,

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -110,6 +110,7 @@ export default class RemoteFile implements GenericFilehandle {
       method: 'GET',
       redirect: 'follow',
       mode: 'cors',
+      credentials: 'include',
       signal,
     }
     const response = await this.fetch(this.url, args)

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -102,6 +102,10 @@ export default class RemoteFile implements GenericFilehandle {
       }
     }
 
+    if (!response) {
+      throw new Error('generic-filehandle failed to fetch')
+    }
+
     if ((response.status === 200 && position === 0) || response.status === 206) {
       const responseData = await this.getBufferFromResponse(response)
       const bytesCopied = responseData.copy(
@@ -158,6 +162,10 @@ export default class RemoteFile implements GenericFilehandle {
     } catch (e) {
       this.prefix = this.corsProxy
       response = await this.fetch(this.prefix + this.url)
+    }
+
+    if (!response) {
+      throw new Error('generic-filehandle failed to fetch')
     }
 
     if (response.status !== 200) {

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -95,15 +95,16 @@ export default class RemoteFile implements GenericFilehandle {
     try {
       response = await this.fetch(this.prefix + this.url, args)
     } catch (e) {
-      console.log(e.message)
       if (e.message === 'Failed to fetch') {
         this.prefix = this.corsProxy
         response = await this.fetch(this.prefix + this.url, args)
+      } else {
+        throw e
       }
     }
 
-    if (!response) {
-      throw new Error('generic-filehandle failed to fetch')
+    if (!response.ok) {
+      throw new Error(`${response.statusText}`)
     }
 
     if ((response.status === 200 && position === 0) || response.status === 206) {

--- a/test/remoteFile.test.ts
+++ b/test/remoteFile.test.ts
@@ -136,7 +136,7 @@ describe('remote file tests', () => {
     const f = new RemoteFile('http://fakehost/test.txt')
     const buf = Buffer.alloc(10)
     const res = f.read(buf, 0, 0, 0)
-    await expect(res).rejects.toThrow(/fetching/)
+    await expect(res).rejects.toThrow(/Internal Server Error/)
   })
   it('throws error if file missing', async () => {
     fetchMock.mock('http://fakehost/test.txt', 404)


### PR DESCRIPTION
Possible fix to #72

Example file that produces a CORS error

http://giab.s3.amazonaws.com/data/AshkenazimTrio/HG003_NA24149_father/NIST_Stanford_Illumina_6kb_matepair/bams/HG003.mate_pair.bam


It is not fixed by refetching in this case (if we made an automatic cors-proxy that might be an option) but it does console.warn to indicate that it is refetching