### PR TITLE
add close methods to all implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Returns a Promise for a buffer or string containing the contents of the whole fi
 
 Returns a Promise for an object containing as much information about the file as is available. At minimum, the `size` of the file will be present.
 
+### async close() : Promise<void>
+
+Closes the filehandle.
 ### Options
 
 The Options object for the constructor, `read` and `readFile` can contain abort signal

--- a/src/blobFile.ts
+++ b/src/blobFile.ts
@@ -107,4 +107,8 @@ export default class BlobFile implements GenericFilehandle {
   public async stat(): Promise<Stats> {
     return { size: this.size }
   }
+
+  public async close(): Promise<void> {
+    return
+  }
 }

--- a/src/filehandle.ts
+++ b/src/filehandle.ts
@@ -43,4 +43,5 @@ export interface GenericFilehandle {
   ): Promise<{ bytesRead: number; buffer: Buffer }>
   readFile(options?: FilehandleOptions | string): Promise<Buffer | string>
   stat(): Promise<Stats>
+  close(): Promise<void>
 }

--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -10,6 +10,7 @@ const fsOpen = fs && promisify(fs.open)
 const fsRead = fs && promisify(fs.read)
 const fsFStat = fs && promisify(fs.fstat)
 const fsReadFile = fs && promisify(fs.readFile)
+const fsClose = fs && promisify(fs.close)
 
 export default class LocalFile implements GenericFilehandle {
   private fd?: any
@@ -44,5 +45,9 @@ export default class LocalFile implements GenericFilehandle {
   // todo memoize
   public async stat(): Promise<any> {
     return fsFStat(await this.getFd())
+  }
+
+  public async close(): Promise<void> {
+    return fsClose(await this.getFd())
   }
 }

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -198,4 +198,8 @@ export default class RemoteFile implements GenericFilehandle {
     }
     return this._stat
   }
+
+  public async close(): Promise<void> {
+    return
+  }
 }


### PR DESCRIPTION
Newer node throws a warning (soon to be an exception) if a node filehandle is not explicitly closed. This means polymorphic code that can accept generic-filehandle needs to close the filehandles, so we need close methods.