### PR TITLE
when library is browserified the code does not work in browser

### DIFF
--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -6,10 +6,10 @@ declare var __webpack_require__: any
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line @typescript-eslint/camelcase
 
-const fsOpen = fs && promisify(fs.open)
-const fsRead = fs && promisify(fs.read)
-const fsFStat = fs && promisify(fs.fstat)
-const fsReadFile = fs && promisify(fs.readFile)
+const fsOpen = fs && fs.open && promisify(fs.open)
+const fsRead = fs && fs.read && promisify(fs.read)
+const fsFStat = fs && fs.fstat && promisify(fs.fstat)
+const fsReadFile = fs && fs.readFile && promisify(fs.readFile)
 
 export default class LocalFile implements GenericFilehandle {
   private fd?: any


### PR DESCRIPTION
This is a small fix for libraries that use browserify to pack and use code in browser. In such situation `fs` does not have `open`/`read`/`stat`/`readFile` functions. Therefore the code fails to load.

---
It could be probably adapted for webpack, so the following
```
declare var __webpack_require__: any

// don't load fs native module if running in webpacked code
const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line @typescript-eslint/camelcase
```
could be reduced to:
```
const fs = require('fs');
```
But the users of webpack would have to add in their `webpack.config.js`

```
node: {
    fs: "empty"
}
```

However, I never used webpack and decided not to touch it.