### PR TITLE
web worker friendly

### DIFF
--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -2,11 +2,16 @@ import fs from 'fs'
 import { promisify } from 'es6-promisify'
 import { GenericFilehandle, FilehandleOptions } from './filehandle'
 
-const fsOpen = fs && promisify(fs.open)
-const fsRead = fs && promisify(fs.read)
-const fsFStat = fs && promisify(fs.fstat)
-const fsReadFile = fs && promisify(fs.readFile)
-const fsClose = fs && promisify(fs.close)
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const fsOpen = fs && promisify(fs.open || (() => {}))
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const fsRead = fs && promisify(fs.read || (() => {}))
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const fsFStat = fs && promisify(fs.fstat || (() => {}))
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const fsReadFile = fs && promisify(fs.readFile || (() => {}))
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const fsClose = fs && promisify(fs.close || (() => {}))
 
 export default class LocalFile implements GenericFilehandle {
   private fd?: any


### PR DESCRIPTION
Hi Colin, 

I am trying to use generic-filehandle on web worker, i guess maybe `fs` doesn't exist in worker, and the package reports error
I tried to put an empty function there and the error is gone.
I guess this should not effect other functions but I am not 100% sure.
Thank you in advance for consideration of this PR.

![image](https://user-images.githubusercontent.com/102806/137343440-1329d9cd-b5ae-4592-8b96-4d650da0ff0a.png)
