### PR TITLE
Add abort to stat on remoteFile

### DIFF
--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -188,10 +188,10 @@ export default class RemoteFile implements GenericFilehandle {
     return this.getBufferFromResponse(response)
   }
 
-  public async stat(): Promise<Stats> {
+  public async stat(opts?: { signal?: AbortSignal }): Promise<Stats> {
     if (!this._stat) {
       const buf = Buffer.allocUnsafe(10)
-      await this.read(buf, 0, 10, 0)
+      await this.read(buf, 0, 10, 0, opts)
       if (!this._stat) {
         throw new Error(`unable to determine size of file at ${this.url}`)
       }


### PR DESCRIPTION
This is pretty inconsequential but seemed like it should exist

Adds abort signal to stat()