### PR TITLE
Add overload to readFile for better return types

### DIFF
--- a/src/blobFile.ts
+++ b/src/blobFile.ts
@@ -87,7 +87,19 @@ export default class BlobFile implements GenericFilehandle {
     return { bytesRead: bytesCopied, buffer: resultBuffer }
   }
 
-  public async readFile(options?: FilehandleOptions | string): Promise<Buffer | string> {
+  public async readFile(): Promise<Buffer>
+  public async readFile(options: BufferEncoding): Promise<string>
+  public async readFile<T extends undefined>(
+    options:
+      | Omit<FilehandleOptions, 'encoding'>
+      | (Omit<FilehandleOptions, 'encoding'> & { encoding: T }),
+  ): Promise<Buffer>
+  public async readFile<T extends BufferEncoding>(
+    options: Omit<FilehandleOptions, 'encoding'> & { encoding: T },
+  ): Promise<string>
+  public async readFile(
+    options?: FilehandleOptions | BufferEncoding,
+  ): Promise<Buffer | string> {
     let encoding
     if (typeof options === 'string') {
       encoding = options

--- a/src/filehandle.ts
+++ b/src/filehandle.ts
@@ -19,7 +19,7 @@ export interface FilehandleOptions {
   signal?: AbortSignal
   headers?: any
   overrides?: any
-  encoding?: string | null
+  encoding?: BufferEncoding
   /**
    * fetch function to use for HTTP requests. defaults to environment's
    * global fetch. if there is no global fetch, and a fetch function is not provided,
@@ -41,7 +41,20 @@ export interface GenericFilehandle {
     position: number,
     opts?: FilehandleOptions,
   ): Promise<{ bytesRead: number; buffer: Buffer }>
-  readFile(options?: FilehandleOptions | string): Promise<Buffer | string>
+  readFile(): Promise<Buffer>
+  readFile(options: BufferEncoding): Promise<string>
+  readFile<T extends undefined>(
+    options:
+      | Omit<FilehandleOptions, 'encoding'>
+      | (Omit<FilehandleOptions, 'encoding'> & { encoding: T }),
+  ): Promise<Buffer>
+  readFile<T extends BufferEncoding>(
+    options: Omit<FilehandleOptions, 'encoding'> & { encoding: T },
+  ): Promise<string>
+  readFile<T extends BufferEncoding>(
+    options: Omit<FilehandleOptions, 'encoding'> & { encoding?: T },
+  ): T extends BufferEncoding ? Promise<Buffer> : Promise<Buffer | string>
+  readFile(options?: FilehandleOptions | BufferEncoding): Promise<Buffer | string>
   stat(): Promise<Stats>
   close(): Promise<void>
 }

--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -35,7 +35,19 @@ export default class LocalFile implements GenericFilehandle {
     return { bytesRead: ret, buffer }
   }
 
-  public async readFile(options?: FilehandleOptions | string): Promise<Buffer | string> {
+  public async readFile(): Promise<Buffer>
+  public async readFile(options: BufferEncoding): Promise<string>
+  public async readFile<T extends undefined>(
+    options:
+      | Omit<FilehandleOptions, 'encoding'>
+      | (Omit<FilehandleOptions, 'encoding'> & { encoding: T }),
+  ): Promise<Buffer>
+  public async readFile<T extends BufferEncoding>(
+    options: Omit<FilehandleOptions, 'encoding'> & { encoding: T },
+  ): Promise<string>
+  public async readFile(
+    options?: FilehandleOptions | BufferEncoding,
+  ): Promise<Buffer | string> {
     return fsReadFile(this.filename, options)
   }
   // todo memoize

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -145,8 +145,21 @@ export default class RemoteFile implements GenericFilehandle {
     throw new Error(`HTTP ${response.status} fetching ${this.url}`)
   }
 
+  public async readFile(): Promise<Buffer>
+  public async readFile(options: BufferEncoding): Promise<string>
+  public async readFile<T extends undefined>(
+    options:
+      | Omit<FilehandleOptions, 'encoding'>
+      | (Omit<FilehandleOptions, 'encoding'> & { encoding: T }),
+  ): Promise<Buffer>
+  public async readFile<T extends BufferEncoding>(
+    options: Omit<FilehandleOptions, 'encoding'> & { encoding: T },
+  ): Promise<string>
+  readFile<T extends BufferEncoding>(
+    options: Omit<FilehandleOptions, 'encoding'> & { encoding: T },
+  ): T extends BufferEncoding ? Promise<Buffer> : Promise<Buffer | string>
   public async readFile(
-    options: FilehandleOptions | string = {},
+    options: FilehandleOptions | BufferEncoding = {},
   ): Promise<Buffer | string> {
     let encoding
     let opts

--- a/test/blobFile.test.ts
+++ b/test/blobFile.test.ts
@@ -18,6 +18,7 @@ describe('blob filehandle', () => {
     expect(fileContents).toEqual('testing\n')
     const fileContents2 = await blobFile.readFile({ encoding: 'utf8' })
     expect(fileContents2).toEqual('testing\n')
+    // @ts-expect-error
     await expect(blobFile.readFile('fakeEncoding')).rejects.toThrow(
       /unsupported encoding/,
     )

--- a/test/remoteFileWithFileUrls.test.ts
+++ b/test/remoteFileWithFileUrls.test.ts
@@ -15,6 +15,7 @@ describe('remote file with file urls', () => {
     expect(fileText).toEqual('testing\n')
     const fileText2 = await f.readFile({ encoding: 'utf8' })
     expect(fileText2).toEqual('testing\n')
+    // @ts-expect-error
     await expect(f.readFile('fakeEncoding')).rejects.toThrow(/encoding/)
   })
   it('reads remote partially', async () => {


### PR DESCRIPTION
Fixes #39 by adding function overloads to `readFile`. Also narrows the type of encoding from `string` to `BufferEncoding`. Return type of `readFile` is now like this:
```ts
const c = await f.readFile()
// c is Buffer
const c = await f.readFile('utf8')
// c is string
const c = await f.readFile({})
// c is Buffer
const c = await f.readFile({ encoding: undefined })
// c is Buffer
const c = await f.readFile({ encoding: 'utf8' })
// c is string
```