### PR TITLE
feat: use builting fs.promises module

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,12 @@
     "genomics"
   ],
   "dependencies": {
-    "es6-promisify": "^6.1.1",
     "file-uri-to-path": "^2.0.0"
   },
   "devDependencies": {
     "@types/fetch-mock": "^7.3.0",
     "@types/jest": "^27.0.3",
-    "@types/node": "^13.13.5",
+    "@types/node": "^17.0.34",
     "@types/range-parser": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",

--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -47,10 +47,12 @@ export default class LocalFile implements GenericFilehandle {
   }
   // todo memoize
   public async stat(): Promise<any> {
-    return this.getFd().then(fd => fd.stat())
+    const fd = await this.getFd()
+    return fd.stat()
   }
 
   public async close(): Promise<void> {
-    return this.getFd().then(fd => fd.close())
+    const fd = await this.getFd()
+    return fd.close()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,10 +811,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.11.tgz#61d4886e2424da73b7b25547f59fdcb534c165a3"
   integrity sha512-lCvvI24L21ZVeIiyIUHZ5Oflv1hhHQ5E1S25IRlKIXaRkVgmXpJMI3wUJkmym2bTbCe+WoIibQnMVAU3FguaOg==
 
-"@types/node@^13.13.5":
-  version "13.13.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.10.tgz#34a9be3cbc409fd235984bd18a130006f5234396"
-  integrity sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q==
+"@types/node@^17.0.34":
+  version "17.0.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.34.tgz#3b0b6a50ff797280b8d000c6281d229f9c538cef"
+  integrity sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1745,11 +1745,6 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-es6-promisify@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.1.1.tgz#46837651b7b06bf6fff893d03f29393668d01621"
-  integrity sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Thanks for all your work on `generic-filehandle`. I am unfortunately running into issues with bundling outside of webpack. This PR replaces the use of `promisify` + `fs` with `fs.promises` API which has been available since Node 10 (I believe).

Node 12 has reached [end of life](https://nodejs.org/en/about/releases/), so I'm curious if this change would be suffcient.
