### PR TITLE
feat: explicit buffer import

### DIFF
--- a/src/blobFile.ts
+++ b/src/blobFile.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { GenericFilehandle, FilehandleOptions, Stats } from './filehandle'
 
 // Using this you can "await" the file like a normal promise

--- a/src/localFile.ts
+++ b/src/localFile.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { Buffer } from 'buffer'
 import { promisify } from 'es6-promisify'
 import { GenericFilehandle, FilehandleOptions } from './filehandle'
 

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import uri2path from 'file-uri-to-path'
 import {
   GenericFilehandle,


### PR DESCRIPTION
Extending from https://github.com/GMOD/generic-filehandle/pull/101#issuecomment-1130915937, using this module with a bundler currently requires a global polyfill for `Buffer`. This can make it challenging to use `generic-filehandle` out of the box in any bundle-less build system using strictly ESM (like Vite).  This PR adds an explicit `Buffer` import so that it can easily be polyfilled.

FWIW, the node `buffer` [docs](https://nodejs.org/api/buffer.html#buffer) include, 

> While the `Buffer` class is available within the global scope, it is still recommended to explicitly reference it via an import or require statement.


