### PR TITLE
Use globalThis to look for fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/cmdcolin"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "files": [
     "dist",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/fetch-mock": "^7.3.0",
     "@types/jest": "^29.2.4",
-    "@types/node": "^18.11.16",
+    "@types/node": "^12.12.6",
     "@types/range-parser": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -7,15 +7,6 @@ import {
   PolyfilledResponse,
 } from './filehandle'
 
-const myGlobal =
-  typeof window !== 'undefined'
-    ? window
-    : typeof self !== 'undefined'
-    ? self
-    : typeof global !== 'undefined'
-    ? global
-    : { fetch: undefined }
-
 export default class RemoteFile implements GenericFilehandle {
   protected url: string
   private _stat?: Stats
@@ -40,8 +31,7 @@ export default class RemoteFile implements GenericFilehandle {
   public constructor(source: string, opts: FilehandleOptions = {}) {
     this.url = source
 
-    const fetch =
-      opts.fetch || (myGlobal.fetch && myGlobal.fetch.bind(myGlobal))
+    const fetch = opts.fetch || globalThis.fetch
     if (!fetch) {
       throw new TypeError(
         `no fetch function supplied, and none found in global environment`,

--- a/src/remoteFile.ts
+++ b/src/remoteFile.ts
@@ -12,6 +12,8 @@ const myGlobal =
     ? window
     : typeof self !== 'undefined'
     ? self
+    : typeof global !== 'undefined'
+    ? global
     : { fetch: undefined }
 
 export default class RemoteFile implements GenericFilehandle {

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,10 +755,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.2.tgz#129cc9ae69f93824f92fac653eebfb4812ab4af9"
   integrity sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==
 
-"@types/node@^18.11.16":
-  version "18.16.19"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.19.tgz#cb03fca8910fdeb7595b755126a8a78144714eea"
-  integrity sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==
+"@types/node@^12.12.6":
+  version "12.20.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
+  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Starting with node 18, node has a built-in fetch function. The node global object is `global`, so this adds a check for that so it can use the built-in fetch.